### PR TITLE
Fix escape inconsistencies in lexicon

### DIFF
--- a/lexique-bym.json
+++ b/lexique-bym.json
@@ -216,7 +216,7 @@
   },
   {
     "mot": "ARTÉMIS",
-    "definition": "_Du grec « arte\nmis » : « de la lumière »._\nAussi appelée Diane, divinité révérée dans toute l'Asie. Il existait un temple en son honneur à Éphèse. Voir Ac. 19:24-37."
+    "definition": "_Du grec « artemis » : « de la lumière »._\nAussi appelée Diane, divinité révérée dans toute l'Asie. Il existait un temple en son honneur à Éphèse. Voir Ac. 19:24-37."
 
   },
   {
@@ -1787,7 +1787,7 @@
   },
   {
     "mot": "SÉJOUR",
-    "definition": "SÉJOUR\tDES\tMORTS,\tde\tl'hébreu\n« she'owl » : « monde souterrain, tombe, enfer, fosse », et _du grec « hades » : « dieu des profondeurs de la terre»._\nLieu de captivité où allaient les âmes de tous les défunts avant le sacrifice du Mashiah. Il était scindé en deux parties séparées par un grand abîme. D'un côté se trouvait un lieu de tourments et de souffrances extrêmes accueillant tous les méchants qui ont vécu dans le péché durant leur vie terrestre et qui n'y ont pas renoncé. D'un autre côté, il y avait le sein d'Abraham où reposaient et séjournaient les âmes des justes qui avaient foi en YHWH. Après la résurrection de Yéhoshoua, ces derniers ont été arrachés du séjour des morts par le Seigneur qui les a emmenés au paradis. Le ciel, en tant que destination des personnes décédées, fut en effet ouvert par le Mashiah après sa résurrection. Par conséquent, le sein d'Abraham n'a jamais accueilli de chrétiens. Le séjour des morts est à présent composé uniquement d'impies; à la fin du monde, il sera jeté avec tous ses habitants dans le lac de feu. Voir Lu. 16:19-31; 1 S. 28:6-20; Mt. 11:23;\nAc. 2:27; Jn. 3:13; Ep. 4:8 et Ap. 20:14.\nNote : L'histoire d'Èl'azar (Lazare) et de\n\nl'homme riche racontée dans Lu. 16:19-31 n'est pas une parabole. À la différence de tous les récits à caractère parabolique contés dans les Écritures, cette histoire mentionne un nom."
+    "definition": "SÉJOUR DES MORTS, de l'hébreu\n« she'owl » : « monde souterrain, tombe, enfer, fosse », et _du grec « hades » : « dieu des profondeurs de la terre»._\nLieu de captivité où allaient les âmes de tous les défunts avant le sacrifice du Mashiah. Il était scindé en deux parties séparées par un grand abîme. D'un côté se trouvait un lieu de tourments et de souffrances extrêmes accueillant tous les méchants qui ont vécu dans le péché durant leur vie terrestre et qui n'y ont pas renoncé. D'un autre côté, il y avait le sein d'Abraham où reposaient et séjournaient les âmes des justes qui avaient foi en YHWH. Après la résurrection de Yéhoshoua, ces derniers ont été arrachés du séjour des morts par le Seigneur qui les a emmenés au paradis. Le ciel, en tant que destination des personnes décédées, fut en effet ouvert par le Mashiah après sa résurrection. Par conséquent, le sein d'Abraham n'a jamais accueilli de chrétiens. Le séjour des morts est à présent composé uniquement d'impies; à la fin du monde, il sera jeté avec tous ses habitants dans le lac de feu. Voir Lu. 16:19-31; 1 S. 28:6-20; Mt. 11:23;\nAc. 2:27; Jn. 3:13; Ep. 4:8 et Ap. 20:14.\nNote : L'histoire d'Èl'azar (Lazare) et de\n\nl'homme riche racontée dans Lu. 16:19-31 n'est pas une parabole. À la différence de tous les récits à caractère parabolique contés dans les Écritures, cette histoire mentionne un nom."
   },
   {
     "mot": "SÉNEVÉ",


### PR DESCRIPTION
## Summary
- remove stray tab escapes from `lexique-bym.json`
- fix an entry where "ARTÉMIS" was split by a newline

## Testing
- `jq '.' lexique-bym.json`

------
https://chatgpt.com/codex/tasks/task_e_6870056c43ec832299853f998d275a76