### PR TITLE
Sanitize dictionary HTML with DOMPurify

### DIFF
--- a/Dictionnaire AJAX.php
+++ b/Dictionnaire AJAX.php
@@ -14,6 +14,7 @@ function afficher_dictionnaire_ajax() {
 
 <link rel="stylesheet" href="<?php echo get_stylesheet_directory_uri(); ?>/css/dictionnaire-biblique-style-unifiee.css">
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
 <script src="<?php echo get_stylesheet_directory_uri(); ?>/js/interface-unifiee.js"></script>
 
 <?php

--- a/Dictionnaire interactif.php
+++ b/Dictionnaire interactif.php
@@ -32,6 +32,7 @@ function afficher_dictionnaire_interactif() {
 
     <!-- JS: Marked.js + Script principal -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script src="<?php echo get_stylesheet_directory_uri(); ?>/js/interface-unifiee.js"></script>
 
     <!-- JS additionnel pour la note et affichage "en cours de traduction" -->

--- a/interface-unifiee.js
+++ b/interface-unifiee.js
@@ -123,9 +123,13 @@ function initDictionaryApp() {
     const htmlSegments = [`<p><a href="#" id="back">← Retour à la liste</a></p>`];
     matches.forEach(({ dict: d, entry }) => {
       const dictName = d === "BYM" ? "Dictionnaire biblique de la BYM" : d === "Easton" ? "Easton's Bible Dictionary" : d;
+      const rawHtml = marked.parse(entry.definition);
+      const cleanHtml = typeof DOMPurify !== "undefined"
+        ? DOMPurify.sanitize(rawHtml)
+        : rawHtml;
       htmlSegments.push(
         `<h2>${entry.mot} — ${dictName}</h2>`,
-        marked.parse(entry.definition)
+        cleanHtml
       );
     });
     content.innerHTML = htmlSegments.join("\n");


### PR DESCRIPTION
## Summary
- sanitize HTML rendered from dictionary definitions in `interface-unifiee.js`
- load DOMPurify in both dictionary shortcodes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878b60e6ab08322a4b6e402d84780cb