### PR TITLE
Use wp_localize_script for dynamic dictionary paths

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,15 @@ add_action('wp_enqueue_scripts', function() {
     wp_enqueue_style('swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css');
     wp_enqueue_script('swiper-js', 'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js', array(), null, true);
     wp_enqueue_script('figuier-swiper', get_stylesheet_directory_uri() . '/js/swiper.js', array('swiper-js'), null, true);
+
+    // ✅ Interface dictionnaire + localisation des sources JSON
+    wp_enqueue_script('figuier-dictionary', get_stylesheet_directory_uri() . '/js/interface-unifiee.js', array(), null, true);
+    $upload_dir = wp_upload_dir();
+    $dictionary_sources = array(
+        'BYM'   => $upload_dir['baseurl'] . '/dictionnaires/lexique-bym.json',
+        'Easton' => $upload_dir['baseurl'] . '/dictionnaires/eastons.json',
+    );
+    wp_localize_script('figuier-dictionary', 'dictionarySources', $dictionary_sources);
 });
 
 // ✅ Fonction pour afficher les derniers posts (grille ou carrousel)

--- a/interface-unifiee.js
+++ b/interface-unifiee.js
@@ -1,10 +1,7 @@
 
 console.log("✅ Interface unifiée du dictionnaire chargée (correction startsWith)");
 
-const sources = {
-  BYM: "/wp-content/uploads/dictionnaires/lexique-bym.json",
-  Easton: "/wp-content/uploads/dictionnaires/eastons.json"
-};
+const sources = window.dictionarySources || {};
 
 let allData = {};
 let currentDict = "BYM";


### PR DESCRIPTION
## Summary
- localize dictionary JSON URLs in `functions.php` using `wp_localize_script`
- read the URLs from the localized object in `interface-unifiee.js`

## Testing
- `php -l functions.php`
- `node --check interface-unifiee.js`

------
https://chatgpt.com/codex/tasks/task_e_6878b76d481083228f23bdeb32479374